### PR TITLE
Recurring event refactor

### DIFF
--- a/app/src/androidTest/java/com/github/onedirection/EventQueriesTest.java
+++ b/app/src/androidTest/java/com/github/onedirection/EventQueriesTest.java
@@ -271,8 +271,9 @@ public class EventQueriesTest {
         ZonedDateTime start = ZonedDateTime.now().truncatedTo(Event.TIME_PRECISION);
         ZonedDateTime end = start.plusHours(1);
         Duration period = Duration.ofDays(1);
-        Recurrence recurrence = new Recurrence(Id.generateRandom(), period, start.plusDays(1000).plusMinutes(2));
-        Event recurrEvent = new Event(Id.generateRandom(), "recurrEvent", "noLocation", Optional.empty(), start, end, Optional.of(recurrence));
+        Id rootId = Id.generateRandom();
+        Recurrence recurrence = new Recurrence(rootId, period, start.plusDays(1000).plusMinutes(2));
+        Event recurrEvent = new Event(rootId, "recurrEvent", "noLocation", Optional.empty(), start, end, Optional.of(recurrence));
         int storeRecurrEvent = queries.addRecurringEvent(recurrEvent).get();
         assertEquals(1001, storeRecurrEvent);
         if(storeRecurrEvent != 0) {
@@ -307,8 +308,9 @@ public class EventQueriesTest {
         ZonedDateTime start = ZonedDateTime.now().truncatedTo(Event.TIME_PRECISION);
         ZonedDateTime end = start.plusHours(1);
         Duration period = Duration.ofDays(1);
-        Recurrence recurrence = new Recurrence(Id.generateRandom(), period, start.plusDays(6));
-        Event recurrEvent = new Event(Id.generateRandom(), "recurrEvent", "noLocation", Optional.empty(), start, end, Optional.of(recurrence));
+        Id rootId = Id.generateRandom();
+        Recurrence recurrence = new Recurrence(rootId, period, start.plusDays(6));
+        Event recurrEvent = new Event(rootId, "recurrEvent", "noLocation", Optional.empty(), start, end, Optional.of(recurrence));
         int storeRecurrEvent = queries.addRecurringEvent(recurrEvent).get();
         assertEquals(7, storeRecurrEvent);
 
@@ -326,9 +328,10 @@ public class EventQueriesTest {
     public void modifyEventToRecurringConvertsItToRecurring() throws ExecutionException, InterruptedException {
         ZonedDateTime time = ZonedDateTime.now();
         Duration period = Duration.ofDays(1);
-        Event event = new Event(Id.generateRandom(), "any", "loc", Optional.empty(), time, time.plusHours(1), Optional.empty());
+        Id rootId = Id.generateRandom();
+        Event event = new Event(rootId, "any", "loc", Optional.empty(), time, time.plusHours(1), Optional.empty());
         assertEquals(event.getId(), ConcreteDatabase.getDatabase().store(event).get());
-        Recurrence recurrence = new Recurrence(Id.generateRandom(), period, time.plusDays(6));
+        Recurrence recurrence = new Recurrence(rootId, period, time.plusDays(6));
         Event recurrEvent = event.setRecurrence(recurrence);
         assertTrue(EventQueries.modifyEvent(ConcreteDatabase.getDatabase(), recurrEvent).get().equals(event.getId()));
         List<Event> eventSeries = new EventQueries(ConcreteDatabase.getDatabase()).getRecurrEventSeriesOf(recurrEvent.getRecurrence().get().getGroupId()).get();
@@ -344,8 +347,9 @@ public class EventQueriesTest {
         ZonedDateTime start = ZonedDateTime.now().truncatedTo(Event.TIME_PRECISION);
         ZonedDateTime end = start.plusHours(1);
         Duration period = Duration.ofDays(1);
-        Recurrence recurrence = new Recurrence(Id.generateRandom(), period, start.plusDays(6));
-        Event recurrEvent = new Event(Id.generateRandom(), "recurrEvent", "noLocation", Optional.empty(), start, end, Optional.of(recurrence));
+        Id rootId = Id.generateRandom();
+        Recurrence recurrence = new Recurrence(rootId, period, start.plusDays(6));
+        Event recurrEvent = new Event(rootId, "recurrEvent", "noLocation", Optional.empty(), start, end, Optional.of(recurrence));
         int storeRecurrEvent = queries.addRecurringEvent(recurrEvent).get();
         assertEquals(7, storeRecurrEvent);
 
@@ -377,8 +381,9 @@ public class EventQueriesTest {
         ZonedDateTime start = ZonedDateTime.now().truncatedTo(Event.TIME_PRECISION);
         ZonedDateTime end = start.plusHours(1);
         Duration period = Duration.ofDays(1);
-        Recurrence recurrence = new Recurrence(Id.generateRandom(), period, start.plusDays(2).plusMinutes(2));
-        Event recurrEvent = new Event(Id.generateRandom(), "recurrEvent", "noLocation", Optional.empty(), start, end, Optional.of(recurrence));
+        Id rootId = Id.generateRandom();
+        Recurrence recurrence = new Recurrence(rootId, period, start.plusDays(2).plusMinutes(2));
+        Event recurrEvent = new Event(rootId, "recurrEvent", "noLocation", Optional.empty(), start, end, Optional.of(recurrence));
         int storeRecurrEvent = queries.addRecurringEvent(recurrEvent).get();
         assertEquals(3, storeRecurrEvent);
         List<Event> recurrEvents = queries.getRecurrEventSeriesOf(recurrence.getGroupId()).get();
@@ -406,8 +411,9 @@ public class EventQueriesTest {
         ZonedDateTime start = ZonedDateTime.now().truncatedTo(Event.TIME_PRECISION);
         ZonedDateTime end = start.plusHours(1);
         Duration period = Duration.ofDays(1);
-        Recurrence recurrence = new Recurrence(Id.generateRandom(), period, start.plusDays(6));
-        Event recurrEvent = new Event(Id.generateRandom(), "recurrEvent", "noLocation", Optional.empty(), start, end, Optional.of(recurrence));
+        Id rootId = Id.generateRandom();
+        Recurrence recurrence = new Recurrence(rootId, period, start.plusDays(6));
+        Event recurrEvent = new Event(rootId, "recurrEvent", "noLocation", Optional.empty(), start, end, Optional.of(recurrence));
         int storeRecurrEvent = queries.addRecurringEvent(recurrEvent).get();
         assertEquals(7, storeRecurrEvent);
         List<Event> events = queries.getRecurrEventSeriesOf(recurrence.getGroupId()).get();
@@ -423,8 +429,9 @@ public class EventQueriesTest {
         ZonedDateTime start = ZonedDateTime.now().truncatedTo(Event.TIME_PRECISION);
         ZonedDateTime end = start.plusHours(1);
         Duration period = Duration.ofDays(1);
-        Recurrence recurrence = new Recurrence(Id.generateRandom(), period, start.plusDays(6));
-        Event recurrEvent = new Event(Id.generateRandom(), "recurrEvent", "noLocation", Optional.empty(), start, end, Optional.of(recurrence));
+        Id rootId = Id.generateRandom();
+        Recurrence recurrence = new Recurrence(rootId, period, start.plusDays(6));
+        Event recurrEvent = new Event(rootId, "recurrEvent", "noLocation", Optional.empty(), start, end, Optional.of(recurrence));
         int storeRecurrEvent = queries.addRecurringEvent(recurrEvent).get();
         assertEquals(7, storeRecurrEvent);
         if(storeRecurrEvent != 0) {
@@ -452,8 +459,9 @@ public class EventQueriesTest {
         ZonedDateTime start = ZonedDateTime.now().truncatedTo(Event.TIME_PRECISION);
         ZonedDateTime end = start.plusHours(1);
         Duration period = Duration.ofDays(1);
-        Recurrence recurrence = new Recurrence(Id.generateRandom(), period, start.plusDays(6));
-        Event recurrEvent = new Event(Id.generateRandom(), "recurrEvent", "noLocation", Optional.empty(), start, end, Optional.of(recurrence));
+        Id rootId = Id.generateRandom();
+        Recurrence recurrence = new Recurrence(rootId, period, start.plusDays(6));
+        Event recurrEvent = new Event(rootId, "recurrEvent", "noLocation", Optional.empty(), start, end, Optional.of(recurrence));
         int storeRecurrEvent = queries.addRecurringEvent(recurrEvent).get();
         assertEquals(7, storeRecurrEvent);
 
@@ -472,8 +480,9 @@ public class EventQueriesTest {
         ZonedDateTime start = ZonedDateTime.now().truncatedTo(Event.TIME_PRECISION);
         ZonedDateTime end = start.plusHours(1);
         Duration period = Duration.ofDays(1);
-        Recurrence recurrence = new Recurrence(Id.generateRandom(), period, start.plusDays(6));
-        Event recurrEvent = new Event(Id.generateRandom(), "recurrEvent", "noLocation", Optional.empty(), start, end, Optional.of(recurrence));
+        Id rootId = Id.generateRandom();
+        Recurrence recurrence = new Recurrence(rootId, period, start.plusDays(6));
+        Event recurrEvent = new Event(rootId, "recurrEvent", "noLocation", Optional.empty(), start, end, Optional.of(recurrence));
         int storeRecurrEvent = queries.addRecurringEvent(recurrEvent).get();
         assertEquals(7, storeRecurrEvent);
 
@@ -492,8 +501,9 @@ public class EventQueriesTest {
         ZonedDateTime start = ZonedDateTime.now().truncatedTo(Event.TIME_PRECISION);
         ZonedDateTime end = start.plusHours(1);
         Duration period = Duration.ofDays(1);
-        Recurrence recurrence = new Recurrence(Id.generateRandom(), period, start.plusDays(6));
-        Event recurrEvent = new Event(Id.generateRandom(), "recurrEvent", "noLocation", Optional.empty(), start, end, Optional.of(recurrence));
+        Id rootId = Id.generateRandom();
+        Recurrence recurrence = new Recurrence(rootId, period, start.plusDays(6));
+        Event recurrEvent = new Event(rootId, "recurrEvent", "noLocation", Optional.empty(), start, end, Optional.of(recurrence));
         int storeRecurrEvent = queries.addRecurringEvent(recurrEvent).get();
         assertEquals(7, storeRecurrEvent);
 
@@ -512,8 +522,9 @@ public class EventQueriesTest {
         ZonedDateTime start = ZonedDateTime.now().truncatedTo(Event.TIME_PRECISION);
         ZonedDateTime end = start.plusHours(1);
         Duration period = Duration.ofDays(1);
-        Recurrence recurrence = new Recurrence(Id.generateRandom(), period, start.plusDays(6));
-        Event recurrEvent = new Event(Id.generateRandom(), "recurrEvent", "noLocation", Optional.empty(), start, end, Optional.of(recurrence));
+        Id rootId = Id.generateRandom();
+        Recurrence recurrence = new Recurrence(rootId, period, start.plusDays(6));
+        Event recurrEvent = new Event(rootId, "recurrEvent", "noLocation", Optional.empty(), start, end, Optional.of(recurrence));
         int storeRecurrEvent = queries.addRecurringEvent(recurrEvent).get();
         assertEquals(7, storeRecurrEvent);
 
@@ -532,8 +543,9 @@ public class EventQueriesTest {
         ZonedDateTime start = ZonedDateTime.now().truncatedTo(Event.TIME_PRECISION);
         ZonedDateTime end = start.plusHours(1);
         Duration period = Duration.ofDays(1);
-        Recurrence recurrence = new Recurrence(Id.generateRandom(), period, start.plusDays(6));
-        Event recurrEvent = new Event(Id.generateRandom(), "recurrEvent", "noLocation", Optional.empty(), start, end, Optional.of(recurrence));
+        Id rootId = Id.generateRandom();
+        Recurrence recurrence = new Recurrence(rootId, period, start.plusDays(6));
+        Event recurrEvent = new Event(rootId, "recurrEvent", "noLocation", Optional.empty(), start, end, Optional.of(recurrence));
         int storeRecurrEvent = queries.addRecurringEvent(recurrEvent).get();
         assertEquals(7, storeRecurrEvent);
         List<Event> events = queries.getRecurrEventSeriesOf(recurrence.getGroupId()).get();
@@ -550,11 +562,14 @@ public class EventQueriesTest {
         ZonedDateTime start = ZonedDateTime.now().truncatedTo(Event.TIME_PRECISION);
         ZonedDateTime end = start.plusHours(1);
         Duration period = Duration.ofDays(1);
-        Event nonRecurrEvent = new Event(Id.generateRandom(), "recurrEvent", "noLocation", Optional.empty(), start, end, Optional.empty());
+        Id rootId = Id.generateRandom();
+        Event nonRecurrEvent = new Event(rootId, "recurrEvent", "noLocation", Optional.empty(), start, end, Optional.empty());
         Id groupId = Id.generateRandom();
         int storeRecurrEvent = queries.convertToRecurring(nonRecurrEvent, new Recurrence(groupId, period, start.plusDays(6))).get();
         assertEquals(7, storeRecurrEvent);
         List<Event> events = queries.getRecurrEventSeriesOf(groupId).get();
+        assertEquals(0, events.size());
+        events = queries.getRecurrEventSeriesOf(rootId).get();
         assertEquals(7, events.size());
         if (storeRecurrEvent != 0) {
             assertTrue(queries.removeRecurrEvents(groupId).get());

--- a/app/src/main/java/com/github/onedirection/database/store/EventStorer.java
+++ b/app/src/main/java/com/github/onedirection/database/store/EventStorer.java
@@ -27,8 +27,6 @@ public class EventStorer extends Storer<Event> {
     public static final String KEY_RECURR_ID = "recurrId";
     public static final String KEY_RECURR_END_TIME = "recurrEndTime";
     public static final String KEY_RECURR_PERIOD = "recurrPeriod";
-    public static final String KEY_RECURR_PREV_ID = "recurrPrevId";
-    public static final String KEY_RECURR_NEXT_ID = "recurrNextId";
 
     public static EventStorer getInstance() {
         return GLOBAL;
@@ -62,12 +60,6 @@ public class EventStorer extends Storer<Event> {
             map.put(KEY_RECURR_ID, recurrence.getGroupId().getUuid());
             map.put(KEY_RECURR_PERIOD, recurrence.getPeriod().getSeconds());
             map.put(KEY_RECURR_END_TIME, recurrence.getEndTime().toEpochSecond());
-            if(recurrence.getPrevEvent().isPresent()) {
-                map.put(KEY_RECURR_PREV_ID, recurrence.getPrevEvent().get().getUuid());
-            }
-            if(recurrence.getNextEvent().isPresent()) {
-                map.put(KEY_RECURR_NEXT_ID, recurrence.getNextEvent().get().getUuid());
-            }
         });
         return map;
     }
@@ -85,16 +77,11 @@ public class EventStorer extends Storer<Event> {
         Double coordLatitude = (Double) m.getOrDefault(KEY_COORD_LATITUDE, null);
         Double coordLongitude = (Double) m.getOrDefault(KEY_COORD_LONGITUDE, null);
         Coordinates coords = coordLatitude == null || coordLongitude == null ? null : new Coordinates(coordLatitude, coordLongitude);
-
         String recurrId = (String) m.getOrDefault(KEY_RECURR_ID, null);
         Long recurrPeriod = (Long) m.getOrDefault(KEY_RECURR_PERIOD, null);
         Long recurrEpochEndTime = (Long) m.getOrDefault(KEY_RECURR_END_TIME, null);
-        String sPrevId = (String) m.getOrDefault(KEY_RECURR_PREV_ID, null);
-        String sNextId = (String) m.getOrDefault(KEY_RECURR_NEXT_ID, null);
-        Optional<Id> prevId = sPrevId == null ? Optional.empty() : Optional.of(new Id(UUID.fromString(sPrevId)));
-        Optional<Id> nextId = sNextId == null ? Optional.empty() : Optional.of(new Id(UUID.fromString(sNextId)));
         Recurrence recurrence = recurrId == null ? null : new Recurrence(new Id(UUID.fromString(recurrId)), Duration.ofSeconds(recurrPeriod),
-                TimeUtils.epochToZonedDateTime(recurrEpochEndTime), prevId, nextId);
+                TimeUtils.epochToZonedDateTime(recurrEpochEndTime));
 
         return new Event(new Id(UUID.fromString(id)), name, locationName, Optional.ofNullable(coords),
                 TimeUtils.epochToZonedDateTime(epochStartTime),

--- a/app/src/main/java/com/github/onedirection/events/Recurrence.java
+++ b/app/src/main/java/com/github/onedirection/events/Recurrence.java
@@ -14,47 +14,31 @@ import javax.annotation.concurrent.Immutable;
 /**
  * Class representing the recurrence of an event.
  * A recurring event is stored as a recurrence series where all its recurring times are stored as individual events.
- * The recurrence series is abstracted as a linked-list of events, where each event in the linked-list has pointers to its neighboring events. The Recurrence class is thus here to append these informations
- * to an event whenever this event belongs to a recurrence series.
- * INVARIANT : A recurrence series has always more than 1 element (event). That is, if an event belongs to a recurrence series (i.e. is recurrent) then its pointers to the previous and next events
- * of the recurrence series are not both null.
+ * The Recurrence class thus represents a recurrence series.
  */
 public class Recurrence implements Serializable {
 
     private Id groupId;
     private Duration period;
     private ZonedDateTime endTime;
-    private Id prevEvent;
-    private Id nextEvent;
 
     /**
      * Constructor of Recurrence
-     * @param groupId (Id) : The id of a specific recurrence series. The event that has this recurrence appended to it belongs to this specific recurrence series
+     * @param groupId (Id) : The id of the recurrence series. The event that has this recurrence appended to it belongs to this specific recurrence series
      * @param period (Duration) : The time interval between each recurrence of the event
-     * @param prev (Id) : The id of the previous event neighbor in the recurrence series
-     * @param next (Id) : The id of the next event neighbor in the recurrence series
+     * @param endTime (ZonedDateTime) : the end time of the recurrence series (end of the recurrence).
      */
-    public Recurrence(Id groupId, Duration period, ZonedDateTime endTime, Optional<Id> prev, Optional<Id> next) {
+    public Recurrence(Id groupId, Duration period, ZonedDateTime endTime) {
         this.groupId = Objects.requireNonNull(groupId);
         this.period = Objects.requireNonNull(period);
         this.endTime = Objects.requireNonNull(endTime);
-        this.prevEvent = Objects.requireNonNull(prev).orElse(null);
-        this.nextEvent = Objects.requireNonNull(next).orElse(null);
     }
 
-    public Recurrence(Id groupId, long periodSeconds, ZonedDateTime endTime, Optional<Id> prev, Optional<Id> next) {
-        this(groupId, Duration.ofSeconds(periodSeconds), endTime, prev, next);
+    public Recurrence(Id groupId, long periodSeconds, ZonedDateTime endTime) {
+        this(groupId, Duration.ofSeconds(periodSeconds), endTime);
     }
 
     public Id getGroupId() { return groupId; }
-
-    public Optional<Id> getPrevEvent() {
-        return Optional.ofNullable(prevEvent);
-    }
-
-    public Optional<Id> getNextEvent() {
-        return Optional.ofNullable(nextEvent);
-    }
 
     public Duration getPeriod() {
         return period;
@@ -62,20 +46,12 @@ public class Recurrence implements Serializable {
 
     public ZonedDateTime getEndTime() { return endTime; }
 
-    public Recurrence setPrevEvent(Optional<Id> newId) {
-        return Objects.requireNonNull(newId).equals(Optional.ofNullable(prevEvent)) ? this : new Recurrence(groupId, period, endTime, newId, Optional.ofNullable(nextEvent));
-    }
-
-    public Recurrence setNextEvent(Optional<Id> newId) {
-        return Objects.requireNonNull(newId).equals(Optional.ofNullable(nextEvent)) ? this : new Recurrence(groupId, period, endTime, Optional.ofNullable(prevEvent), newId);
-    }
-
     public Recurrence setPeriod(Duration newPeriod) {
-        return Objects.requireNonNull(newPeriod).equals(period) ? this : new Recurrence(groupId, newPeriod, endTime, Optional.ofNullable(prevEvent), Optional.ofNullable(nextEvent));
+        return Objects.requireNonNull(newPeriod).equals(period) ? this : new Recurrence(groupId, newPeriod, endTime);
     }
 
     public Recurrence setEndTime(ZonedDateTime newEndTime) {
-        return Objects.requireNonNull(newEndTime).equals(endTime) ? this : new Recurrence(groupId, period, newEndTime, Optional.ofNullable(prevEvent), Optional.ofNullable(nextEvent));
+        return Objects.requireNonNull(newEndTime).equals(endTime) ? this : new Recurrence(groupId, period, newEndTime);
     }
 
     public Recurrence setPeriodFromSeconds(long periodSeconds) {
@@ -85,11 +61,9 @@ public class Recurrence implements Serializable {
 
     @Override
     public String toString() {
-        return "[" + groupId + "] " +
-                "Recurrence period: " + period +
-                " [" + (prevEvent == null ? "" : prevEvent) + ", " +
-                (nextEvent == null ? "" : nextEvent) + "] " +
-                "Ending: " + endTime;
+        return "[" + groupId + ", " +
+                "Recurrence period: " + period + ", " +
+                "Ending: " + endTime + "]";
     }
 
     @Override
@@ -98,13 +72,11 @@ public class Recurrence implements Serializable {
         Recurrence recurrence = (Recurrence) o;
         return groupId.equals(recurrence.groupId) &&
                 period.equals(recurrence.period) &&
-                endTime.equals(recurrence.endTime) &&
-                getPrevEvent().equals(recurrence.getPrevEvent()) &&
-                getNextEvent().equals(recurrence.getNextEvent());
+                endTime.equals(recurrence.endTime);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(groupId, period, endTime, prevEvent, nextEvent);
+        return Objects.hash(groupId, period, endTime);
     }
 }

--- a/app/src/main/java/com/github/onedirection/events/Recurrence.java
+++ b/app/src/main/java/com/github/onedirection/events/Recurrence.java
@@ -37,14 +37,6 @@ public class Recurrence implements Serializable {
     public Recurrence(Id groupId, long periodSeconds, ZonedDateTime endTime) {
         this(groupId, Duration.ofSeconds(periodSeconds), endTime);
     }
-  
-    public Recurrence(Id groupId, Duration period, ZonedDateTime endTime) {
-        this(groupId, period, endTime, Optional.empty(), Optional.empty());
-    }
-
-    public Recurrence(Id groupId, long periodSeconds, ZonedDateTime endTime, Optional<Id> prev, Optional<Id> next) {
-        this(groupId, Duration.ofSeconds(periodSeconds), endTime, prev, next);
-    }
 
     public Id getGroupId() { return groupId; }
 

--- a/app/src/test/java/com/github/onedirection/EventTest.java
+++ b/app/src/test/java/com/github/onedirection/EventTest.java
@@ -32,7 +32,7 @@ public class EventTest {
     private final static ZonedDateTime START_TIME = ZonedDateTime.now().truncatedTo(Event.TIME_PRECISION);
     private final static Duration DURATION = Duration.of(1, ChronoUnit.HOURS);
     private final static ZonedDateTime END_TIME = ZonedDateTime.now().plus(DURATION).truncatedTo(Event.TIME_PRECISION);
-    private final static Recurrence RECURRING_PERIOD = new Recurrence(Id.generateRandom(), Duration.ofDays(1), END_TIME, Optional.of(Id.generateRandom()), Optional.of(Id.generateRandom())); //Daily
+    private final static Recurrence RECURRING_PERIOD = new Recurrence(Id.generateRandom(), Duration.ofDays(1), END_TIME); //Daily
 
     private final static Event EVENT = new Event(ID, NAME, LOCATION, START_TIME, END_TIME, RECURRING_PERIOD);
 
@@ -87,7 +87,7 @@ public class EventTest {
 
     @Test
     public void testEventSetRecurringPeriodAndGet() {
-        final Recurrence recurringPeriod = new Recurrence(RECURRING_PERIOD.getGroupId(), Duration.ofDays(7), END_TIME, RECURRING_PERIOD.getPrevEvent(), RECURRING_PERIOD.getNextEvent());
+        final Recurrence recurringPeriod = new Recurrence(RECURRING_PERIOD.getGroupId(), Duration.ofDays(7), END_TIME);
 
         assertThrows(NullPointerException.class, () -> EVENT.setRecurrence(null));
         Event eventChanged = EVENT.setRecurrence(recurringPeriod);

--- a/app/src/test/java/com/github/onedirection/RecurrenceTest.java
+++ b/app/src/test/java/com/github/onedirection/RecurrenceTest.java
@@ -27,17 +27,13 @@ public class RecurrenceTest {
     private final static Id GROUP_ID = Id.generateRandom();
     private final static Duration DURATION_WEEK = Duration.ofDays(7);
     private final static ZonedDateTime END_TIME = ZonedDateTime.now().truncatedTo(Event.TIME_PRECISION);
-    private final static Id PREV_EVENT_ID = Id.generateRandom();
-    private final static Id NEXT_EVENT_ID = Id.generateRandom();
-    private final static Recurrence RECURRENCE = new Recurrence(GROUP_ID, DURATION_WEEK, END_TIME, Optional.of(PREV_EVENT_ID), Optional.of(NEXT_EVENT_ID));
+    private final static Recurrence RECURRENCE = new Recurrence(GROUP_ID, DURATION_WEEK, END_TIME);
 
     @Test
     public void testRecurrenceWithNullArgument() {
-        assertThrows(NullPointerException.class, () -> new Recurrence(null, DURATION_WEEK, END_TIME, Optional.of(PREV_EVENT_ID), Optional.of(NEXT_EVENT_ID)));
-        assertThrows(NullPointerException.class, () -> new Recurrence(GROUP_ID, null, END_TIME, Optional.of(PREV_EVENT_ID), Optional.of(NEXT_EVENT_ID)));
-        assertThrows(NullPointerException.class, () -> new Recurrence(GROUP_ID, DURATION_WEEK, null, Optional.of(PREV_EVENT_ID), Optional.of(NEXT_EVENT_ID)));
-        assertThrows(NullPointerException.class, () -> new Recurrence(GROUP_ID, DURATION_WEEK, END_TIME, null, Optional.of(NEXT_EVENT_ID)));
-        assertThrows(NullPointerException.class, () -> new Recurrence(GROUP_ID, DURATION_WEEK, END_TIME, Optional.of(PREV_EVENT_ID), null));
+        assertThrows(NullPointerException.class, () -> new Recurrence(null, DURATION_WEEK, END_TIME));
+        assertThrows(NullPointerException.class, () -> new Recurrence(GROUP_ID, null, END_TIME));
+        assertThrows(NullPointerException.class, () -> new Recurrence(GROUP_ID, DURATION_WEEK, null));
     }
 
     @Test
@@ -45,13 +41,11 @@ public class RecurrenceTest {
         assertEquals(GROUP_ID, RECURRENCE.getGroupId());
         assertEquals(DURATION_WEEK, RECURRENCE.getPeriod());
         assertEquals(END_TIME, RECURRENCE.getEndTime());
-        assertEquals(PREV_EVENT_ID, RECURRENCE.getPrevEvent().orElse(null));
-        assertEquals(NEXT_EVENT_ID, RECURRENCE.getNextEvent().orElse(null));
     }
 
     @Test
     public void durationFromSecondsIsCorrect() {
-        Recurrence fromSeconds = new Recurrence(GROUP_ID, SECONDS_WEEK, END_TIME, Optional.of(PREV_EVENT_ID), Optional.of(NEXT_EVENT_ID));
+        Recurrence fromSeconds = new Recurrence(GROUP_ID, SECONDS_WEEK, END_TIME);
         assertEquals(RECURRENCE, fromSeconds);
     }
 
@@ -60,13 +54,6 @@ public class RecurrenceTest {
         Duration d = Duration.ofSeconds(SECONDS_WEEK); //Week
         long secondsFromDuration = d.getSeconds();
         assertEquals(SECONDS_WEEK, secondsFromDuration);
-    }
-
-    @Test
-    public void recurrenceHasNullEventPointers() {
-        Recurrence nullEventPointers = new Recurrence(GROUP_ID, DURATION_WEEK, END_TIME, Optional.ofNullable(null), Optional.ofNullable(null));
-        assertEquals(Optional.empty(), nullEventPointers.getPrevEvent());
-        assertEquals(Optional.empty(), nullEventPointers.getNextEvent());
     }
 
     @Test
@@ -93,67 +80,31 @@ public class RecurrenceTest {
     }
 
     @Test
-    public void testSetPrevEventGet() {
-        final Id newId = Id.generateRandom();
-
-        assertThrows(NullPointerException.class, () -> RECURRENCE.setPrevEvent(null));
-        Recurrence recurrChanged = RECURRENCE.setPrevEvent(Optional.of(newId));
-        assertEquals(newId, recurrChanged.getPrevEvent().orElse(null));
-        recurrChanged = RECURRENCE.setPrevEvent(Optional.ofNullable(null));
-        assertEquals(Optional.empty(), recurrChanged.getPrevEvent());
-        assertEquals(PREV_EVENT_ID, RECURRENCE.getPrevEvent().orElse(null));
-        assertThat(RECURRENCE.setPrevEvent(Optional.of(PREV_EVENT_ID)), sameInstance(RECURRENCE));
-    }
-
-    @Test
-    public void testSetNextEventGet() {
-        final Id newId = Id.generateRandom();
-
-        assertThrows(NullPointerException.class, () -> RECURRENCE.setNextEvent(null));
-        Recurrence recurrChanged = RECURRENCE.setNextEvent(Optional.of(newId));
-        assertEquals(newId, recurrChanged.getNextEvent().orElse(null));
-        recurrChanged = RECURRENCE.setNextEvent(Optional.ofNullable(null));
-        assertEquals(Optional.empty(), recurrChanged.getNextEvent());
-        assertEquals(NEXT_EVENT_ID, RECURRENCE.getNextEvent().orElse(null));
-        assertThat(RECURRENCE.setNextEvent(Optional.of(NEXT_EVENT_ID)), sameInstance(RECURRENCE));
-    }
-
-    @Test
     public void toStringContainsAllFields() {
         String str = RECURRENCE.toString();
         assertThat(str, containsString(GROUP_ID.toString()));
         assertThat(str, containsString(DURATION_WEEK.toString()));
         assertThat(str, containsString(END_TIME.toString()));
-        assertThat(str, containsString(PREV_EVENT_ID.toString()));
-        assertThat(str, containsString(NEXT_EVENT_ID.toString()));
     }
 
     @Test
     public void equalsBehavesAsExpected() {
-        Recurrence recurr1 = new Recurrence(GROUP_ID, DURATION_WEEK, END_TIME, Optional.of(PREV_EVENT_ID), Optional.of(NEXT_EVENT_ID));
+        Recurrence recurr1 = new Recurrence(GROUP_ID, DURATION_WEEK, END_TIME);
         assertThat(RECURRENCE, is(RECURRENCE));
         assertThat(RECURRENCE, is(recurr1));
-        Recurrence recurr2 = new Recurrence(Id.generateRandom(), DURATION_WEEK, END_TIME, Optional.of(PREV_EVENT_ID), Optional.of(NEXT_EVENT_ID));
+        Recurrence recurr2 = new Recurrence(Id.generateRandom(), DURATION_WEEK, END_TIME);
         assertThat(RECURRENCE, not(is(recurr2)));
-        Recurrence recurr3 = new Recurrence(GROUP_ID, SECONDS_WEEK, END_TIME, Optional.of(PREV_EVENT_ID), Optional.of(NEXT_EVENT_ID));
+        Recurrence recurr3 = new Recurrence(GROUP_ID, SECONDS_WEEK, END_TIME);
         assertThat(RECURRENCE, is(recurr3));
-        Recurrence recurr4 = new Recurrence(GROUP_ID, DURATION_WEEK.minusMinutes(4), END_TIME, Optional.of(PREV_EVENT_ID), Optional.of(NEXT_EVENT_ID));
+        Recurrence recurr4 = new Recurrence(GROUP_ID, DURATION_WEEK.minusMinutes(4), END_TIME);
         assertThat(RECURRENCE, not(is(recurr4)));
-        Recurrence recurr5 = new Recurrence(GROUP_ID, DURATION_WEEK, END_TIME, Optional.of(Id.generateRandom()), Optional.of(NEXT_EVENT_ID));
-        Recurrence recurr6 = new Recurrence(GROUP_ID, DURATION_WEEK, END_TIME, Optional.of(PREV_EVENT_ID), Optional.of(Id.generateRandom()));
-        Recurrence recurr7 = new Recurrence(GROUP_ID, DURATION_WEEK, END_TIME, Optional.ofNullable(null), Optional.of(NEXT_EVENT_ID));
-        Recurrence recurr8 = new Recurrence(GROUP_ID, DURATION_WEEK, END_TIME, Optional.of(PREV_EVENT_ID), Optional.ofNullable(null));
+        Recurrence recurr5 = new Recurrence(GROUP_ID, DURATION_WEEK, END_TIME.plusHours(2));
         assertThat(RECURRENCE, not(is(recurr5)));
-        assertThat(RECURRENCE, not(is(recurr6)));
-        assertThat(RECURRENCE, not(is(recurr7)));
-        assertThat(RECURRENCE, not(is(recurr8)));
-        Recurrence recurr9 = new Recurrence(GROUP_ID, DURATION_WEEK, END_TIME.plusHours(2), Optional.of(PREV_EVENT_ID), Optional.of(NEXT_EVENT_ID));
-        assertThat(RECURRENCE, not(is(recurr9)));
     }
 
     @Test
     public void hashCodeIsEqualCompatible(){
-        Recurrence event = new Recurrence(GROUP_ID, DURATION_WEEK, END_TIME, Optional.of(PREV_EVENT_ID), Optional.of(NEXT_EVENT_ID));
+        Recurrence event = new Recurrence(GROUP_ID, DURATION_WEEK, END_TIME);
         assertThat(event, is(RECURRENCE));
         assertThat(event, not(sameInstance(RECURRENCE)));
         assertThat(event.hashCode(), is(RECURRENCE.hashCode()));


### PR DESCRIPTION
- No more pointers to prev event and next event in the Recurrence class (speeds up the queries a lot)
- Got rid of the following invariant : a recurrence series has more than 1 element (events). Now, this is authorized, as it doesn't bother anything and it isn't necessary.
- Added a method to modify an event. This method makes any modification on an event, except if it is recurrent (in that case modifying the recurrence series id or the period of the recurrence is forbidden, whereas modifying the end time of the recurrence is accepted and supported). 